### PR TITLE
Mark package as Typed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,4 +4,4 @@ ignore = E501
 show_source = True
 statistics = True
 count = True
-exclude = .git,__pycache__, venv
+exclude = .direnv,.git,__pycache__,venv

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+warn_unused_configs = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
+
+[mypy-tests.*]
+disallow_any_generics = False
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = False

--- a/pyais/ais_types.py
+++ b/pyais/ais_types.py
@@ -33,5 +33,5 @@ class AISType(IntEnum):
     LONG_RANGE_BROADCAST = 27
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return AISType.NOT_IMPLEMENTED

--- a/pyais/constants.py
+++ b/pyais/constants.py
@@ -22,7 +22,7 @@ class NavigationStatus(IntEnum):
     Undefined = 15
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return NavigationStatus.Undefined
 
 
@@ -33,7 +33,7 @@ class ManeuverIndicator(IntEnum):
     UNDEFINED = 3
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return ManeuverIndicator.UNDEFINED
 
 
@@ -49,7 +49,7 @@ class EpfdType(IntEnum):
     Galileo = 8
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return EpfdType.Undefined
 
 
@@ -123,27 +123,28 @@ class ShipType(IntEnum):
     OtherType_NoAdditionalInformation = 99
 
     @classmethod
-    def _missing_(cls, value) -> int:
-        if 24 < value < 30:
-            return ShipType.WIG_Reserved
+    def _missing_(cls, value: object) -> int:
+        if isinstance(value, int):
+            if 24 < value < 30:
+                return ShipType.WIG_Reserved
 
-        if 44 < value < 49:
-            return ShipType.HSC_Reserved
+            if 44 < value < 49:
+                return ShipType.HSC_Reserved
 
-        if 55 < value < 58:
-            return ShipType.SPARE
+            if 55 < value < 58:
+                return ShipType.SPARE
 
-        if 64 < value < 69:
-            return ShipType.Passenger_Reserved
+            if 64 < value < 69:
+                return ShipType.Passenger_Reserved
 
-        if 74 < value < 79:
-            return ShipType.Cargo_Reserved
+            if 74 < value < 79:
+                return ShipType.Cargo_Reserved
 
-        if 84 < value < 89:
-            return ShipType.Tanker_Reserved
+            if 84 < value < 89:
+                return ShipType.Tanker_Reserved
 
-        if 94 < value < 99:
-            return ShipType.OtherType_Reserved
+            if 94 < value < 99:
+                return ShipType.OtherType_Reserved
 
         return ShipType.NotAvailable
 
@@ -198,7 +199,7 @@ class NavAid(IntEnum):
     LIGHT_VESSEL = 31
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return NavAid.DEFAULT
 
 
@@ -209,7 +210,7 @@ class TransmitMode(IntEnum):
     RESERVED = 3
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return TransmitMode.TXA_TXB_RXA_RXB
 
 
@@ -223,11 +224,12 @@ class StationType(IntEnum):
     REGIONAL = 6
 
     @classmethod
-    def _missing_(cls, value) -> int:
-        if 6 <= value <= 9:
-            return StationType.REGIONAL
-        if 10 <= value <= 15:
-            return StationType.RESERVED
+    def _missing_(cls, value: object) -> int:
+        if isinstance(value, int):
+            if 6 <= value <= 9:
+                return StationType.REGIONAL
+            if 10 <= value <= 15:
+                return StationType.RESERVED
         return StationType.ALL
 
 
@@ -246,5 +248,5 @@ class StationIntervals(IntEnum):
     RESERVED = 11
 
     @classmethod
-    def _missing_(cls, value) -> int:
+    def _missing_(cls, value: object) -> int:
         return StationIntervals.RESERVED

--- a/pyais/decode.py
+++ b/pyais/decode.py
@@ -1,5 +1,5 @@
-import typing
 from functools import partial
+from typing import Any, Dict
 
 import bitarray  # type: ignore
 
@@ -14,10 +14,11 @@ from pyais.constants import (
     NavAid
 )
 from pyais.exceptions import UnknownMessageException
+from pyais import messages
 from pyais.util import get_int, encode_bin_as_ascii6
 
 
-def decode_msg_1(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_1(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     AIS Vessel position report using SOTDMA (Self-Organizing Time Division Multiple Access)
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_types_1_2_and_3_position_report_class_a
@@ -42,14 +43,14 @@ def decode_msg_1(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_2(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_2(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """AIS Vessel position report using SOTDMA (Self-Organizing Time Division Multiple Access)
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_types_1_2_and_3_position_report_class_a
     """
     return decode_msg_1(bit_arr)
 
 
-def decode_msg_3(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_3(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     AIS Vessel position report using ITDMA (Incremental Time Division Multiple Access)
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_types_1_2_and_3_position_report_class_a
@@ -57,7 +58,7 @@ def decode_msg_3(bit_arr: bitarray.bitarray) -> typing.Dict:
     return decode_msg_1(bit_arr)
 
 
-def decode_msg_4(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_4(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     AIS Vessel position report using SOTDMA (Self-Organizing Time Division Multiple Access)
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_4_base_station_report
@@ -82,7 +83,7 @@ def decode_msg_4(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_5(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_5(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Static and Voyage Related Data
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_5_static_and_voyage_related_data
@@ -112,7 +113,7 @@ def decode_msg_5(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_6(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_6(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Binary Addresses Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_4_base_station_report
@@ -131,7 +132,7 @@ def decode_msg_6(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_7(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_7(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Binary Acknowledge
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_7_binary_acknowledge
@@ -152,7 +153,7 @@ def decode_msg_7(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_8(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_8(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Binary Acknowledge
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_8_binary_broadcast_message
@@ -168,7 +169,7 @@ def decode_msg_8(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_9(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_9(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Standard SAR Aircraft Position Report
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_9_standard_sar_aircraft_position_report
@@ -192,7 +193,7 @@ def decode_msg_9(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_10(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_10(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     UTC/Date Inquiry
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_10_utc_date_inquiry
@@ -206,7 +207,7 @@ def decode_msg_10(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_11(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_11(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     UTC/Date Response
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_11_utc_date_response
@@ -214,7 +215,7 @@ def decode_msg_11(bit_arr: bitarray.bitarray) -> typing.Dict:
     return decode_msg_4(bit_arr)
 
 
-def decode_msg_12(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_12(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Addressed Safety-Related Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_12_addressed_safety_related_message
@@ -231,14 +232,14 @@ def decode_msg_12(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_13(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_13(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Identical to type 7
     """
     return decode_msg_7(bit_arr)
 
 
-def decode_msg_14(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_14(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Safety-Related Broadcast Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_14_safety_related_broadcast_message
@@ -252,7 +253,7 @@ def decode_msg_14(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_15(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_15(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Interrogation
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_15_interrogation
@@ -273,7 +274,7 @@ def decode_msg_15(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_16(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_16(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Assignment Mode Command
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_16_assignment_mode_command
@@ -292,7 +293,7 @@ def decode_msg_16(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_17(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_17(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     DGNSS Broadcast Binary Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_17_dgnss_broadcast_binary_message
@@ -308,7 +309,7 @@ def decode_msg_17(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_18(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_18(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Standard Class B CS Position Report
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_18_standard_class_b_cs_position_report
@@ -337,7 +338,7 @@ def decode_msg_18(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_19(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_19(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Extended Class B CS Position Report
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_19_extended_class_b_cs_position_report
@@ -368,7 +369,7 @@ def decode_msg_19(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_20(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_20(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Data Link Management Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_20_data_link_management_message
@@ -401,7 +402,7 @@ def decode_msg_20(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_21(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_21(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Aid-to-Navigation Report
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_21_aid_to_navigation_report
@@ -435,7 +436,7 @@ def decode_msg_21(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_22(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_22(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Channel Management
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_22_channel_management
@@ -457,7 +458,7 @@ def decode_msg_22(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
     # Broadcast
-    d: typing.Dict[str, float] = {}
+    d: Dict[str, float] = {}
     if data['addressed']:
         d = {
             'dest1': get_int_from_data(69, 99),
@@ -476,7 +477,7 @@ def decode_msg_22(bit_arr: bitarray.bitarray) -> typing.Dict:
     return data
 
 
-def decode_msg_23(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_23(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Group Assignment Command
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_23_group_assignment_command
@@ -500,20 +501,20 @@ def decode_msg_23(bit_arr: bitarray.bitarray) -> typing.Dict:
     }
 
 
-def decode_msg_24(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_24(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Static Data Report
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_24_static_data_report
     """
     get_int_from_data = partial(get_int, bit_arr)
-    data: typing.Dict = {
+    data = {
         'type': get_int_from_data(0, 6),
         'repeat': get_int_from_data(8, 8),
         'mmsi': get_int_from_data(8, 38),
         'partno': get_int_from_data(38, 40)
     }
 
-    d: typing.Dict
+    d: Dict[str, Any]
     if not data['partno']:
         # Part A
         d = {
@@ -537,7 +538,7 @@ def decode_msg_24(bit_arr: bitarray.bitarray) -> typing.Dict:
     return data
 
 
-def decode_msg_25(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_25(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Single Slot Binary Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_25_single_slot_binary_message
@@ -578,7 +579,7 @@ def decode_msg_25(bit_arr: bitarray.bitarray) -> typing.Dict:
     return data
 
 
-def decode_msg_26(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_26(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Multiple Slot Binary Message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_26_multiple_slot_binary_message
@@ -622,7 +623,7 @@ def decode_msg_26(bit_arr: bitarray.bitarray) -> typing.Dict:
     return data
 
 
-def decode_msg_27(bit_arr: bitarray.bitarray) -> typing.Dict:
+def decode_msg_27(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
     """
     Long Range AIS Broadcast message
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_27_long_range_ais_broadcast_message
@@ -677,7 +678,7 @@ DECODE_MSG = [
 ]
 
 
-def _decode(msg) -> typing.Dict:
+def _decode(msg: "messages.NMEAMessage") -> Dict[str, Any]:
     """
     Decodes a given NMEA message.
     """
@@ -687,7 +688,7 @@ def _decode(msg) -> typing.Dict:
         raise UnknownMessageException(f"The message {msg} is not currently supported!") from e
 
 
-def decode(msg) -> typing.Dict:
+def decode(msg: "messages.NMEAMessage") -> Dict[str, Any]:
     """
     Decodes a given message.
 

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -1,5 +1,5 @@
 import json
-import typing
+from typing import Any, Optional, Sequence
 
 from bitarray import bitarray  # type: ignore
 
@@ -78,8 +78,8 @@ class NMEAMessage(object):
     def __str__(self) -> str:
         return str(self.raw)
 
-    def __dict__(self):
-        def serializable(o):
+    def __dict__(self):  # type: ignore
+        def serializable(o: object) -> Any:
             if isinstance(o, bytes):
                 return o.decode('utf-8')
             elif isinstance(o, bitarray):
@@ -94,7 +94,7 @@ class NMEAMessage(object):
             ]
         )
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return all([getattr(self, attr) == getattr(other, attr) for attr in self.__slots__])
 
     @classmethod
@@ -106,7 +106,7 @@ class NMEAMessage(object):
         return cls(nmea_byte_str)
 
     @classmethod
-    def assemble_from_iterable(cls, messages: typing.Sequence) -> "NMEAMessage":
+    def assemble_from_iterable(cls, messages: Sequence["NMEAMessage"]) -> "NMEAMessage":
         """
         Assemble a multiline message from a sequence of NMEA messages.
         :param messages: Sequence of NMEA messages
@@ -142,7 +142,7 @@ class NMEAMessage(object):
     def fragment_count(self) -> int:
         return self.count
 
-    def decode(self, silent: bool = True) -> typing.Optional["AISMessage"]:
+    def decode(self, silent: bool = True) -> Optional["AISMessage"]:
         """
         Decode the message content.
 
@@ -165,22 +165,22 @@ class AISMessage(object):
     def __init__(self, nmea_message: NMEAMessage) -> None:
         self.nmea: NMEAMessage = nmea_message
         self.msg_type: AISType = AISType(nmea_message.ais_id)
-        self.content: typing.Dict = decode(self.nmea)
+        self.content = decode(self.nmea)
 
-    def __getitem__(self, item: str) -> typing.Any:
+    def __getitem__(self, item: str) -> Any:
         return self.content[item]
 
     def __str__(self) -> str:
         return str(self.content)
 
-    def __dict__(self):
+    def __dict__(self):  # type: ignore
         return {
-            'nmea': self.nmea.__dict__(),
+            'nmea': self.nmea.__dict__(),  # type: ignore
             'decoded': self.content
         }
 
     def to_json(self) -> str:
         return json.dumps(
-            self.__dict__(),
+            self.__dict__(),  # type: ignore
             indent=4
         )

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from bitarray import bitarray  # type: ignore
 
@@ -78,7 +78,7 @@ class NMEAMessage(object):
     def __str__(self) -> str:
         return str(self.raw)
 
-    def __dict__(self):  # type: ignore
+    def asdict(self) -> Dict[str, Any]:
         def serializable(o: object) -> Any:
             if isinstance(o, bytes):
                 return o.decode('utf-8')
@@ -173,14 +173,14 @@ class AISMessage(object):
     def __str__(self) -> str:
         return str(self.content)
 
-    def __dict__(self):  # type: ignore
+    def asdict(self) -> Dict[str, Any]:
         return {
-            'nmea': self.nmea.__dict__(),  # type: ignore
+            'nmea': self.nmea.asdict(),
             'decoded': self.content
         }
 
     def to_json(self) -> str:
         return json.dumps(
-            self.__dict__(),  # type: ignore
+            self.asdict(),
             indent=4
         )

--- a/pyais/util.py
+++ b/pyais/util.py
@@ -1,9 +1,14 @@
 from collections import OrderedDict
 from functools import partial, reduce
 from operator import xor
-from typing import Generator, Sequence, Any
+from typing import Any, Generator, Hashable, TYPE_CHECKING
 
 from bitarray import bitarray  # type: ignore
+
+if TYPE_CHECKING:
+    BaseDict = OrderedDict[Hashable, Any]
+else:
+    BaseDict = OrderedDict
 
 from_bytes = partial(int.from_bytes, byteorder="big")
 from_bytes_signed = partial(int.from_bytes, byteorder="big", signed=True)
@@ -29,7 +34,7 @@ def decode_into_bit_array(data: bytes) -> bitarray:
     return bit_arr
 
 
-def chunks(sequence: Sequence, n: int) -> Generator[bitarray, None, None]:
+def chunks(sequence: bitarray, n: int) -> Generator[bitarray, None, None]:
     """Yield successive n-sized chunks from l."""
     return (sequence[i:i + n] for i in range(0, len(sequence), n))
 
@@ -87,7 +92,7 @@ def compute_checksum(msg: bytes) -> int:
     return reduce(xor, msg)
 
 
-class FixedSizeDict(OrderedDict):
+class FixedSizeDict(BaseDict):
     """
     Fixed sized dictionary that only contains up to N keys.
     """
@@ -96,7 +101,7 @@ class FixedSizeDict(OrderedDict):
         super().__init__()
         self.maxlen: int = maxlen
 
-    def __setitem__(self, k: str, v: Any) -> None:
+    def __setitem__(self, k: Hashable, v: Any) -> None:
         super().__setitem__(k, v)
         # if the maximum number is reach delete the oldest n keys
         if len(self) >= self.maxlen:

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,17 @@ setuptools.setup(
     url="https://github.com/M0r13n/pyais",
     license="MIT",
     packages=setuptools.find_packages(),
+    package_data={
+        "pyais": ["py.typed"]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
         "Topic :: Communications",
-        "Topic :: System :: Networking"
+        "Topic :: System :: Networking",
+        "Typing :: Typed",
     ],
     keywords=["AIS", "ship", "decoding", "nmea"],
     python_requires='>=3.6',


### PR DESCRIPTION
Hello @M0r13n, thank you for a very nice library!

Would you consider marking the package as typed according to [pep 561](https://www.python.org/dev/peps/pep-0561/)? This way others (e.g., me!) could take advantage of the type annotations in their own dependent code. This PR hopefully addresses this and a little more:
- Add an empty `py.typed` file to the root package directory to mark the package as typed according to pep 561.
- Make the source code pass mypy with the `--strict` flag. It was quite close to doing this already so I couldn't resist! This will also warn about missing type annotations in the future.
- Rename the `__dict__()` methods of `NMEAMessage` and `AISMessage` to `asdict()`. I split this out into its own commit which can be removed in case you think this is a too breaking change.

The reason for the last change above is that the type checker gets confused by having a custom method override the [__dict__](https://docs.python.org/3.10/library/stdtypes.html#object.__dict__) instance attribute (and so did I for a moment to be honest). I'm hoping that this method can be considered internal since it's not documented (to my knowledge) but this is of course up to your judgement. An alternative is to add a couple of `# type: ignore` comments to the code. I went with the name `asdict()` inspired by Python's [data classes](https://www.python.org/dev/peps/pep-0557/#asdict-and-astuple-function-names).

As mentioned, making the code pass `mypy --strict` was mainly about adding some missing type annotations. It got a little messier in `pyais.stream` since the `_fobj` instance variable in the base `Stream` class could be either `BinaryIO`, `socket` or `None` depending on the derived class. It was possible to please the type checker by making the base class generic and I think this turned out to be a pretty unobtrusive change but take a look to see if you agree.

Happy holidays!