### PR TITLE
corrects ShipType.Trug to Tug

### DIFF
--- a/pyais/constants.py
+++ b/pyais/constants.py
@@ -102,7 +102,7 @@ class ShipType(IntEnum):
     # 50's
     PilotVessel = 50
     SearchAndRescueVessel = 51
-    Trug = 52
+    Tug = 52
     PortTender = 53
     AntiPollutionEquipment = 54
     LawEnforcement = 55


### PR DESCRIPTION
Looks like ShipType enum has a .Trug (52) which I believe should be a tug boat. I updated it to be .Tug