### PR TITLE
Uniformly name shiptype as part of #32

### DIFF
--- a/pyais/decode.py
+++ b/pyais/decode.py
@@ -494,7 +494,7 @@ def decode_msg_23(bit_arr: bitarray.bitarray) -> Dict[str, Any]:
         'sw_lat': get_int_from_data(93, 110, signed=True) * 0.1,
 
         'station_type': StationType(get_int_from_data(110, 114)),
-        'ship_type': ShipType(get_int_from_data(114, 122)),
+        'shiptype': ShipType(get_int_from_data(114, 122)),
         'txrx': TransmitMode(get_int_from_data(144, 146)),
         'interval': StationIntervals(get_int_from_data(146, 150)),
         'quiet': get_int_from_data(150, 154),

--- a/tests/test_ais.py
+++ b/tests/test_ais.py
@@ -461,6 +461,7 @@ class TestAIS(unittest.TestCase):
         assert msg['type'] == 23
         assert msg['mmsi'] == "002268120"
         assert msg['ne_lon'] == 157.8
+        assert msg['shiptype'] == ShipType.NotAvailable
         assert round(msg['ne_lat'], 1) == 3064.2
         assert round(msg['sw_lon'], 1) == 109.6
         assert round(msg['sw_lat'], 1) == 3040.8


### PR DESCRIPTION
`grep -ri ship_type ./pyais` does not return anything. So it is save to say, that `shiptype` is now uniformly used.