### PR TITLE
Fix enums of NoneType throwing when calling asdict with enum_as_int=True

### DIFF
--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -435,10 +435,9 @@ class Payload(abc.ABC):
         @return: The message as a dictionary.
         """
         if enum_as_int:
-            d = {slt: int(getattr(self, slt)) if slt in ENUM_FIELDS else getattr(self, slt) for slt in self.__slots__}
+            return { slt: None if getattr(self, slt) is None else int(getattr(self, slt)) if slt in ENUM_FIELDS else getattr(self, slt) for slt in self.__slots__ }
         else:
-            d = {slt: getattr(self, slt) for slt in self.__slots__}
-        return d
+            return { slt: getattr(self, slt) for slt in self.__slots__ }
 
     def to_json(self) -> str:
         return json.dumps(


### PR DESCRIPTION
Fix for the issue mentioned here: https://github.com/M0r13n/pyais/issues/46#issuecomment-1054857188

Did a quick perf test repeating the call 99k times and looks like there is effectively no change with the majority of time taken up by helper functions as seen below in the `SnakeViz` graph.

![image](https://user-images.githubusercontent.com/6373693/156277938-974e1478-2f14-4a9b-8088-095c2b451bc9.png)
