### PR TITLE
fix wrong URL to GPSD for MessageType6

### DIFF
--- a/docs/messages.rst
+++ b/docs/messages.rst
@@ -536,7 +536,7 @@ MessageType5
             * default: 0
 MessageType6
     Binary Addresses Message
-    Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_4_base_station_report
+    Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_6_binary_addressed_message
 
 
     Attributes:


### PR DESCRIPTION
Update wrong URL reference for MessageType6 in documentation