### PR TITLE
Correct fillbits in multipart encoding

### DIFF
--- a/pyais/encode.py
+++ b/pyais/encode.py
@@ -66,8 +66,6 @@ def ais_to_nmea_0183(payload: str, ais_talker_id: str, radio_channel: str, fill_
         dummy_message = tpl.format(ais_talker_id, frag_cnt, frag_num, seq_id, radio_channel, chunk, fill_bits, 0)
         checksum = compute_checksum(dummy_message)
         fill_bits_frag = fill_bits if frag_num == frag_cnt else 0 # Make sure we set fill bits only for last fragment
-        print(frag_cnt, frag_num, fill_bits_frag)
-
         msg = tpl.format(ais_talker_id, frag_cnt, frag_num, seq_id, radio_channel, chunk, fill_bits_frag, checksum)
         messages.append(msg)
 
@@ -99,7 +97,6 @@ def encode_dict(data: DATA_DICT, talker_id: str = "AIVDO", radio_channel: str = 
     ais_type = get_ais_type(data)
     payload = data_to_payload(ais_type, data)
     armored_payload, fill_bits = payload.encode()
-    print(payload, armored_payload, fill_bits)
     return ais_to_nmea_0183(armored_payload, talker_id, radio_channel, fill_bits)
 
 

--- a/pyais/encode.py
+++ b/pyais/encode.py
@@ -65,7 +65,10 @@ def ais_to_nmea_0183(payload: str, ais_talker_id: str, radio_channel: str, fill_
         tpl = "!{},{},{},{},{},{},{}*{:02X}"
         dummy_message = tpl.format(ais_talker_id, frag_cnt, frag_num, seq_id, radio_channel, chunk, fill_bits, 0)
         checksum = compute_checksum(dummy_message)
-        msg = tpl.format(ais_talker_id, frag_cnt, frag_num, seq_id, radio_channel, chunk, fill_bits, checksum)
+        fill_bits_frag = fill_bits if frag_num == frag_cnt else 0 # Make sure we set fill bits only for last fragment
+        print(frag_cnt, frag_num, fill_bits_frag)
+
+        msg = tpl.format(ais_talker_id, frag_cnt, frag_num, seq_id, radio_channel, chunk, fill_bits_frag, checksum)
         messages.append(msg)
 
     return messages
@@ -96,6 +99,7 @@ def encode_dict(data: DATA_DICT, talker_id: str = "AIVDO", radio_channel: str = 
     ais_type = get_ais_type(data)
     payload = data_to_payload(ais_type, data)
     armored_payload, fill_bits = payload.encode()
+    print(payload, armored_payload, fill_bits)
     return ais_to_nmea_0183(armored_payload, talker_id, radio_channel, fill_bits)
 
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -270,6 +270,19 @@ class TestAIS(unittest.TestCase):
 
         ensure_type_for_msg_dict(msg)
 
+    def test_msg_type_8_multipart(self):
+        msgs = ['!AIVDO,2,1,,A,8=?eN>0000:C=4B1KTTsgLoUelGetEo0FoWr8jo=?045TNv5Tge6sAUl4MKWo,0*5F', '!AIVDO,2,2,,A,vhOL9NIPln:BsP0=BLOiiCbE7;SKsSJfALeATapHfdm6Tl,2*79']
+        
+        msg = decode(*msgs).asdict()
+
+        assert msg["repeat"] == 0
+        assert msg["mmsi"] == 888888888
+        assert msg['dac'] == 0
+        assert msg["fid"] == 0
+        assert msg["data"] == b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM"
+        
+        ensure_type_for_msg_dict(msg)
+
     def test_msg_type_9(self):
         msg = decode(b"!AIVDM,1,1,,B,91b55wi;hbOS@OdQAC062Ch2089h,0*30").asdict()
         assert msg['msg_type'] == 9

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -655,8 +655,8 @@ def test_encode_type_15():
 def test_encode_type_14():
     data = {'mmsi': '351809000', 'repeat': 0, 'text': 'RCVD YR TEST MSG', 'type': 14}
     encoded = encode_dict(data)
-    assert encoded[0] == "!AIVDO,3,1,,A,>5?Per18=HB1U:1@E=B0m<L00000000000000000000000000000000000000,2*51"
-    assert encoded[1] == "!AIVDO,3,2,,A,0000000000000000000000000000000000000000000000000000000000000,2*17"
+    assert encoded[0] == "!AIVDO,3,1,,A,>5?Per18=HB1U:1@E=B0m<L00000000000000000000000000000000000000,0*51"
+    assert encoded[1] == "!AIVDO,3,2,,A,0000000000000000000000000000000000000000000000000000000000000,0*17"
     assert encoded[2] == "!AIVDO,3,3,,A,0000000000000000000000000000000000000000000000,2*26"
 
 
@@ -754,6 +754,17 @@ def test_encode_type_8():
     }
     encoded = encode_dict(data, radio_channel="B", talker_id="AIVDM")
     assert encoded[0] == "!AIVDM,1,1,,B,85Mwp`1Kf0>dg4Huwt@,2*5B"
+
+def tes_encode_type_8_multi():
+    data = {
+        'dac': 0,
+        "data": b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM",
+        "fid": 0,
+        "mmsi": 888888888,
+        "type": 8
+    }
+    encoded = encode_dict(data)
+    assert encoded == ['!AIVDO,2,1,,A,8=?eN>0000:C=4B1KTTsgLoUelGetEo0FoWr8jo=?045TNv5Tge6sAUl4MKWo,0*5F', '!AIVDO,2,2,,A,vhOL9NIPln:BsP0=BLOiiCbE7;SKsSJfALeATapHfdm6Tl,2*79']
 
 
 def test_encode_type_7():
@@ -859,7 +870,7 @@ def test_encode_type_5_issue_59():
 
     encoded_part_1 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[0]
     encoded_part_2 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[1]
-    assert encoded_part_1 == "!AIVDM,2,1,,B,55?MbV02;H;s<HtKP00EHE:0@T4@Dl0000000000L961O5Gf0P3QEp6ClRh00,2*77"
+    assert encoded_part_1 == "!AIVDM,2,1,,B,55?MbV02;H;s<HtKP00EHE:0@T4@Dl0000000000L961O5Gf0P3QEp6ClRh00,0*77"
     assert encoded_part_2 == "!AIVDM,2,2,,B,0000000000,2*27"
 
 
@@ -892,7 +903,7 @@ def test_encode_type_5():
 
     encoded_part_1 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[0]
     encoded_part_2 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[1]  #
-    assert encoded_part_1 == "!AIVDM,2,1,,B,55?MbV02;H;s<HtKP00EHE:0@T4@Dl0000000000L961O5Gf0NSQEp6ClRh00,2*09"
+    assert encoded_part_1 == "!AIVDM,2,1,,B,55?MbV02;H;s<HtKP00EHE:0@T4@Dl0000000000L961O5Gf0NSQEp6ClRh00,0*09"
     assert encoded_part_2 == "!AIVDM,2,2,,B,0000000000,2*27"
 
 
@@ -903,7 +914,7 @@ def test_encode_type_5_default():
     data = {'mmsi': 123456789, 'type': 5}
     encoded_part_1 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[0]
     encoded_part_2 = encode_dict(data, radio_channel="B", talker_id="AIVDM")[1]
-    assert encoded_part_1 == "!AIVDM,2,1,,B,51mg=5@000000000000000000000000000000000000000000000000000000,2*62"
+    assert encoded_part_1 == "!AIVDM,2,1,,B,51mg=5@000000000000000000000000000000000000000000000000000000,0*62"
     assert encoded_part_2 == "!AIVDM,2,2,,B,0000000000,2*27"
 
 
@@ -1002,7 +1013,7 @@ def test_lon_too_large():
 def test_ship_name_too_lon():
     msg = MessageType5.create(mmsi="123", shipname="Titanic Titanic Titanic")
     encoded = encode_msg(msg)
-    assert encoded[0] == "!AIVDO,2,1,,A,50000Nh000000000001@U@4pT>1@U@4pT>1@U@40000000000000000000000,2*56"
+    assert encoded[0] == "!AIVDO,2,1,,A,50000Nh000000000001@U@4pT>1@U@4pT>1@U@40000000000000000000000,0*56"
     assert encoded[1] == "!AIVDO,2,2,,A,0000000000,2*26"
 
 


### PR DESCRIPTION
The fillbits field was set to fillbits value for every fragment, instead of only the last one. The fillbits field for every other fragment should be set to 0. 
This leaded to multipart AIS encoding error. 

I corrected the bug in encode.py, and corrected the related tests. 