### PR TITLE
remove unnecessary type casts

### DIFF
--- a/pyais/constants.py
+++ b/pyais/constants.py
@@ -1,5 +1,5 @@
 import typing
-from enum import IntEnum, Enum
+from enum import Enum, IntEnum
 
 # Keywords
 UNDEFINED = 'Undefined'
@@ -9,7 +9,7 @@ ANSI_RED = '\x1b[31m'
 ANSI_RESET = '\x1b[0m'
 
 
-class TurnRate(IntEnum):
+class TurnRate(float, Enum):
     # Source: https://gpsd.gitlab.io/gpsd/AIVDM.html#_types_1_2_and_3_position_report_class_a
     # turning right at more than 5deg/30s (No TI available)
     NO_TI_RIGHT = 127

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -673,7 +673,7 @@ class Payload(abc.ABC):
                 # All fields that did not fit into the bit array are None
                 kwargs[field.name] = None
                 continue
-            
+
             width = field.metadata['width']
             d_type = field.metadata['d_type']
             converter = field.metadata['to_converter']

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -573,6 +573,10 @@ class Payload(abc.ABC):
 
         d_type = field.metadata['d_type']
 
+        if type(val) == d_type:
+            # The value is already of the correct type -> nothing to do
+            return val
+
         try:
             coerced_val = coerce_val(val, d_type)
         except ValueError as err:
@@ -659,32 +663,38 @@ class Payload(abc.ABC):
     def from_bitarray(cls, bit_arr: bitarray) -> "ANY_MESSAGE":
         cur: int = 0
         end: int = 0
+        length: int = len(bit_arr)
         kwargs: typing.Dict[str, typing.Any] = {}
 
         # Iterate over the bits until the last bit of the bitarray or all fields are fully decoded
         for field in cls.fields():
 
-            if end >= len(bit_arr):
+            if end >= length:
                 # All fields that did not fit into the bit array are None
                 kwargs[field.name] = None
                 continue
-
+            
             width = field.metadata['width']
             d_type = field.metadata['d_type']
             converter = field.metadata['to_converter']
 
-            end = min(len(bit_arr), cur + width)
+            end = min(length, cur + width)
             bits = bit_arr[cur: end]
 
             val: typing.Any
             # Get the correct data type and decoding function
-            if d_type in (int, bool, float):
+            if d_type == int or d_type == bool or d_type == float:
                 shift = (8 - ((end - cur) % 8)) % 8
                 if field.metadata['signed']:
                     val = from_bytes_signed(bits) >> shift
                 else:
                     val = from_bytes(bits) >> shift
-                val = d_type(val)
+
+                if d_type == float:
+                    val = float(val)
+                elif d_type == bool:
+                    val = bool(val)
+
             elif d_type == str:
                 val = decode_bin_as_ascii6(bits)
             elif d_type == bytes:
@@ -693,10 +703,7 @@ class Payload(abc.ABC):
                 raise InvalidDataTypeException(d_type)
 
             val = converter(val) if converter is not None else val
-
-            val = cls.__force_type(field, val)
             kwargs[field.name] = val
-
             cur = end
 
         return cls(**kwargs)  # type:ignore
@@ -762,11 +769,11 @@ def from_mmsi(v: typing.Union[str, int]) -> int:
     return int(v)
 
 
-def to_turn(turn: typing.Union[int, float]) -> typing.Union[float, int, TurnRate]:
+def to_turn(turn: typing.Union[int, float]) -> typing.Union[float, TurnRate]:
     if not turn:
         return 0.0
     elif abs(turn) == 127:
-        return TurnRate(int(turn))
+        return TurnRate(turn)
     elif abs(turn) == 128:
         return TurnRate.NO_TI_DEFAULT
 

--- a/pyais/util.py
+++ b/pyais/util.py
@@ -28,8 +28,9 @@ def decode_into_bit_array(data: bytes, fill_bits: int = 0) -> bitarray:
     :param fill_bits:   Number of trailing fill bits to be ignored
     :return:
     """
-    bit_arr = bitarray()
+    bit_str = ''
     length = len(data)
+
     for i, c in enumerate(data):
         if not 0x20 <= c <= 0x7e:
             raise NonPrintableCharacterException(f"Non printable character: '{hex(c)}'")
@@ -41,10 +42,11 @@ def decode_into_bit_array(data: bytes, fill_bits: int = 0) -> bitarray:
         if i == length - 1 and fill_bits:
             # The last part be shorter than 6 bits and contain fill bits
             c = c >> fill_bits
-            bit_arr += bitarray(f'{c:b}'.zfill(6 - fill_bits))
+            bit_str += f'{c:b}'.zfill(6 - fill_bits)
         else:
-            bit_arr += bitarray(f'{c:06b}')
+            bit_str += f'{c:06b}'
 
+    bit_arr = bitarray(bit_str)
     return bit_arr
 
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -55,6 +55,8 @@ class TestAIS(unittest.TestCase):
     The latter sometimes is a bit weird and therefore I used aislib to verify my results.
     """
 
+    maxDiff = None
+
     def test_to_json(self):
         json_dump = decode(b"!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w428D;,0*24").to_json()
         text = textwrap.dedent("""{


### PR DESCRIPTION
**Before**

```bash
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.849092721939087
ERRORS 2
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.7922966480255127
ERRORS 2
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.8527872562408447
ERRORS 2
```

**After**

```bash
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.1997904777526855
ERRORS 2
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.1322197914123535
ERRORS 2
$ /home/leon/projects/pyais/venv/bin/python /home/leon/projects/pyais/performance.py
Decoding 82758 messages took: 3.2007410526275635
ERRORS 2
```



So the total runtime is reduced from ~3.8s to ~3.2s which is about 15% better. Even tough performance was never the primary goal of pyais, this is still a nice to have. 