### PR TITLE
yield file object instead of all lines

### DIFF
--- a/pyais/stream.py
+++ b/pyais/stream.py
@@ -172,7 +172,7 @@ class BinaryIOStream(Stream[BinaryIO]):
         super().__init__(file)
 
     def read(self) -> Generator[bytes, None, None]:
-        yield from self._fobj.readlines()
+        yield from self._fobj
 
 
 class FileReaderStream(BinaryIOStream):


### PR DESCRIPTION
Noticed while processing a large file that it was going slow. Dug into the code and found that we were reading the whole file upfront exceeding the memory limit of my machine. Instead we can yield the object and let the processing happen line by line.