### PR TITLE
Fix ROT decode rounding

### DIFF
--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -777,7 +777,7 @@ def to_turn(turn: typing.Union[int, float]) -> typing.Union[float, TurnRate]:
     elif abs(turn) == 128:
         return TurnRate.NO_TI_DEFAULT
 
-    return math.copysign(int((turn / 4.733) ** 2), turn)
+    return math.copysign(round((turn / 4.733) ** 2), turn)
 
 
 def from_turn(turn: typing.Optional[typing.Union[int, float, TurnRate]]) -> int:

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1364,12 +1364,25 @@ class TestAIS(unittest.TestCase):
         encoded = encode_dict({"msg_type": 1, "mmsi": 123, "turn": 64.0})[0]
         assert encoded == "!AIVDO,1,1,,A,10000Nh9P0000000000000000000,0*6A"
 
+    def test_rot_encode_decode(self):
+        encoded = encode_dict({"msg_type": 1, "mmsi": 123, "turn": 2.0})[0]
+        assert decode(encoded).turn == 2.0
+
+        encoded = encode_dict({"msg_type": 1, "mmsi": 123, "turn": 3.0})[0]
+        assert decode(encoded).turn == 3.0
+
+        encoded = encode_dict({"msg_type": 1, "mmsi": 123, "turn": 4.0})[0]
+        assert decode(encoded).turn == 4.0
+
+        encoded = encode_dict({"msg_type": 1, "mmsi": 123, "turn": 5.0})[0]
+        assert decode(encoded).turn == 5.0
+
     def test_rot_decode_yields_expected_values(self):
-        assert decode(b"!AIVDM,1,1,,A,14QIG<5620KF@Gl:L9DI4o8N0P00,0*28").turn == 25.0
+        assert decode(b"!AIVDM,1,1,,A,14QIG<5620KF@Gl:L9DI4o8N0P00,0*28").turn == 26.0
         assert decode(b"!AIVDM,1,1,,B,13u><=gsQj0mQW:Q1<wRL28P0@:4,0*32").turn == -14.0
-        assert decode(b"!AIVDM,1,1,,A,14SSRt021O0?bK@MO7H6QUA600Rg,0*12").turn == 2.0
-        assert decode(b"!AIVDM,1,1,,2,13aB:Hhuh0PHjEFNKJg@11sH08J=,0*1E").turn == -3.0
-        assert decode(b"!AIVDM,1,1,,A,16:VFv0k0I`KQPpFATG4SgvT40:v,0*7B").turn == -120.0
+        assert decode(b"!AIVDM,1,1,,A,14SSRt021O0?bK@MO7H6QUA600Rg,0*12").turn == 3.0
+        assert decode(b"!AIVDM,1,1,,2,13aB:Hhuh0PHjEFNKJg@11sH08J=,0*1E").turn == -4.0
+        assert decode(b"!AIVDM,1,1,,A,16:VFv0k0I`KQPpFATG4SgvT40:v,0*7B").turn == -121.0
         assert decode(b"!AIVDM,1,1,,B,16:D3F0:15`5ogh<O?bk>1Dd2L1<,0*0B").turn == 71.0
 
     def test_get_sotdma_comm_state_utc_direct(self):


### PR DESCRIPTION
Hello,

When encoding and decoding some messages I found an inconsistency in ROT (`turn`). For some values it's inconsistent because `to_turn` function is truncating instead of rounding.

You can see the effect in the following screenshots:

![image](https://github.com/M0r13n/pyais/assets/25179743/5000f521-f79e-44a1-a761-0d066414af84)

![image](https://github.com/M0r13n/pyais/assets/25179743/0a5910c1-4d7d-41ed-9700-800084147328)

I added a new test `test_rot_encode_decode` to cover this.

Related PR: https://github.com/M0r13n/pyais/pull/74 . I see that `to_turn` was rounding in the past, but it was changed for some reason. Could you shed some light on this?