### PR TITLE
fix: increase sub message hour field length

### DIFF
--- a/pyais/util.py
+++ b/pyais/util.py
@@ -372,7 +372,7 @@ def get_sotdma_comm_state(radio: int) -> Dict[str, typing.Optional[int]]:
     if slot_timeout == 0:
         result['slot_offset'] = sub_msg
     elif slot_timeout == 1:
-        result['utc_hour'] = (sub_msg >> 9) & 0xf
+        result['utc_hour'] = (sub_msg >> 9) & 0x1f
         result['utc_minute'] = (sub_msg >> 2) & 0x3f
     elif slot_timeout in (2, 4, 6):
         result['slot_number'] = sub_msg


### PR DESCRIPTION
The length of the _UTC hour and minute_ field of the sub message must be increased from 4 bits to 5 bits, otherwise an incorrect time will be output. This is always the case if the hour of a message is greater than 15. An example:  
```python
decoded = pyais.decode('!AIVDM,1,1,,B,133ga6PP0lPPE>4M3G@DpOwTR61p,0*33')
com = decoded.get_communication_state()
print(f"Time: {com['utc_hour']}:{com['utc_minute']}")
# Outputs: Time: 0:30
```
The actual output should be _16:30_. This can also be cross-checked with online AIS decoders such as the [Maritec](https://www.maritec.co.za/aisvdmvdodecoding) one.

