### PR TITLE
Stream NMEA messages containing any type of metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,39 @@ for msg in IterMessages(fake_stream):
     print(msg.decode())
 ```
 
+We can also have any king of metadata for each message:
+
+```py
+import re
+from typing import Union, Tuple
+from pyais import IterMessages
+
+enhanced_fake_stream = [
+    b"[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
+    b"[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
+    b"[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B",
+    b"[2024-07-19 08:45:35.301] !AIVDM,1,1,,B,13eaJF0P00Qd388Eew6aagvH85Ip,0*45",
+    b"[2024-07-19 08:45:40.021] !AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A",
+    b"[2024-07-19 08:45:40.074] !AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F",
+]
+
+
+# Create a custom parsing function:
+# - NMEA message must be always in the first position and in bytes
+# - For flexibility purposes, consider cases where the data can be bytes or string
+def parse_function(msg: Union[str, bytes], encoding: str = 'utf-8') -> Tuple[bytes, str]:
+    if isinstance(msg, bytes):
+        msg = msg.decode(encoding)
+    nmea_message = re.search(".* (.*)", msg).group(1)  # NMEA
+    metadata = re.search("(.*) .*", msg).group(1)  # Metadata
+
+    return bytes(nmea_message, encoding), metadata
+
+
+for message, infos in IterMessages(enhanced_fake_stream, parse_function):
+    print(infos, message.decode())
+```
+
 ## Live feed
 
 The [Norwegian Coastal Administration](https://kystverket.no/en/navigation-and-monitoring/ais/access-to-ais-data/) offers real-time AIS data.

--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ for msg in IterMessages(fake_stream):
     print(msg.decode())
 ```
 
-We can also have any king of metadata for each message:
+We can also have any kind of metadata for each message:
 
 ```py
 import re
 from typing import Union, Tuple
 from pyais import IterMessages
 
-enhanced_fake_stream = [
+fake_stream = [
     b"[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
     b"[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
     b"[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B",
@@ -169,7 +169,7 @@ def parse_function(msg: Union[str, bytes], encoding: str = 'utf-8') -> Tuple[byt
     return bytes(nmea_message, encoding), metadata
 
 
-for message, infos in IterMessages(enhanced_fake_stream, parse_function):
+for message, infos in IterMessages(fake_stream, parse_function):
     print(infos, message.decode())
 ```
 

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -1,3 +1,5 @@
+import re
+from typing import Tuple, Union
 from pyais import decode, IterMessages
 
 # Decode a single part using decode
@@ -32,7 +34,7 @@ decoded_b = decode(b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05")
 decoded_s = decode("!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05")
 assert decoded_b == decoded_s
 
-# Lets say you have some kind of stream of messages. Than you can use `IterMessages` to decode the messages:
+# Lets say you have some kind of stream of messages. Then you can use `IterMessages` to decode the messages:
 fake_stream = [
     b"!AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
     b"!AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
@@ -41,5 +43,45 @@ fake_stream = [
     b"!AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A",
     b"!AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F",
 ]
-for msg in IterMessages(fake_stream):
-    print(msg.decode())
+
+for message in IterMessages(fake_stream):
+    print(message.decode())
+
+# We can also have any king of metadata for each message:
+enhanced_fake_stream = [
+    b"[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
+    b"[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
+    b"[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B",
+    b"[2024-07-19 08:45:35.301] !AIVDM,1,1,,B,13eaJF0P00Qd388Eew6aagvH85Ip,0*45",
+    b"[2024-07-19 08:45:40.021] !AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A",
+    b"[2024-07-19 08:45:40.074] !AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F",
+]
+
+
+# Create a custom parsing function:
+# - NMEA message must be always in the first position and in bytes
+# - For flexibility purposes, consider cases where the data can be bytes or string
+def parse_function(msg: Union[str, bytes], encoding: str = 'utf-8') -> Tuple[bytes, str]:
+    if isinstance(msg, bytes):
+        msg = msg.decode(encoding)
+    nmea_message = re.search(".* (.*)", msg).group(1)  # NMEA
+    metadata = re.search("(.*) .*", msg).group(1)  # Metadata
+
+    return bytes(nmea_message, encoding), metadata
+
+
+for message, infos in IterMessages(enhanced_fake_stream, parse_function):
+    print(infos, message.decode())
+
+# Whatever if the data are bytes or strings
+enhanced_fake_stream = [
+    "[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
+    "[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
+    "[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B",
+    "[2024-07-19 08:45:35.301] !AIVDM,1,1,,B,13eaJF0P00Qd388Eew6aagvH85Ip,0*45",
+    "[2024-07-19 08:45:40.021] !AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A",
+    "[2024-07-19 08:45:40.074] !AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F",
+]
+
+for message, infos in IterMessages.from_strings(enhanced_fake_stream, parse_function):
+    print(infos, message.decode())

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -68,12 +68,12 @@ enhanced_fake_stream = [
 def parse_function(msg: bytes) -> Tuple[bytes, Any]:
     nmea_message = re.search(b'.* (.*)', msg).group(1)  # NMEA
     metadata_bytes = re.search(b'(.*) .*', msg).group(1)  # Metadata
-    date = datetime.strptime(metadata_bytes.decode("utf-8"), "[%Y-%m-%d %X.%f]")
-    return nmea_message, date
+    timestamp = datetime.strptime(metadata_bytes.decode("utf-8"), "[%Y-%m-%d %X.%f]").timestamp()
+    return nmea_message, timestamp
 
 
 for message, infos in IterMessages(enhanced_fake_stream, parse_function):
-    print(infos, message.decode())
+    print(f"Timestamp: {infos} --", message.decode())
 
 # Whatever if the data are bytes or strings
 enhanced_fake_stream = [
@@ -86,4 +86,4 @@ enhanced_fake_stream = [
 ]
 
 for message, infos in IterMessages.from_strings(enhanced_fake_stream, parse_function):
-    print(infos, message.decode())
+    print(f"Timestamp: {infos} ->", message.decode())

--- a/examples/enhanced_sample.ais
+++ b/examples/enhanced_sample.ais
@@ -1,0 +1,12 @@
+# taken from https://www.aishub.net/ais-dispatcher
+[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23
+[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F
+[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B
+[2024-07-19 08:45:35.301] !AIVDM,1,1,,B,13eaJF0P00Qd388Eew6aagvH85Ip,0*45
+[2024-07-19 08:45:40.021] !AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A
+[2024-07-19 08:45:40.074] !AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F
+# Lines with a leading `#` are ignored
+# Also invalid lines or invalid messages are ignored
+IamNotAnAisMessage1111
+# Tag blocks are also supported
+[2024-07-19 08:47:40.074] \g:1-2-73874,n:157036,s:r003669945,c:12415440354*A\!AIVDM,1,1,,B,15N4cJ005Jrek0H@9nDW5608EP,013

--- a/examples/file_stream.py
+++ b/examples/file_stream.py
@@ -9,7 +9,7 @@ When reading a file, the following things are important to know:
 """
 import pathlib
 import re
-from typing import Tuple, Union
+from typing import Tuple, Any
 
 from pyais.stream import FileReaderStream
 
@@ -18,14 +18,16 @@ filename = pathlib.Path(__file__).parent.joinpath('sample.ais')
 for message in FileReaderStream(str(filename)):
     print(message.decode())
 
+# Create a custom parsing function:
+# - NMEA message must be always in the first position
+# - Always consider that the NMEA message are bytes when parsing
+# - The metadata field can be also parsed during the process: he could
+# be anything (string, float, datetime, etc.)
+def parse_function(msg: bytes) -> Tuple[bytes, Any]:
+    nmea_message = re.search(b'.* (.*)', msg).group(1)  # NMEA
+    metadata = re.search(b'(.*) .*', msg).group(1)  # Metadata
 
-def parse_function(msg: Union[str, bytes], encoding: str = 'utf-8') -> Tuple[bytes, str]:
-    if isinstance(msg, bytes):
-        msg = msg.decode(encoding)
-    nmea_message = re.search(".* (.*)", msg).group(1)  # NMEA
-    metadata = re.search("(.*) .*", msg).group(1)  # Metadata
-
-    return bytes(nmea_message, encoding), metadata
+    return nmea_message, metadata
 
 
 filename = pathlib.Path(__file__).parent.joinpath('enhanced_sample.ais')

--- a/examples/file_stream.py
+++ b/examples/file_stream.py
@@ -8,11 +8,27 @@ When reading a file, the following things are important to know:
 - invalid lines are skipped
 """
 import pathlib
+import re
+from typing import Tuple, Union
 
 from pyais.stream import FileReaderStream
 
 filename = pathlib.Path(__file__).parent.joinpath('sample.ais')
 
-for msg in FileReaderStream(str(filename)):
-    decoded = msg.decode()
-    print(decoded)
+for message in FileReaderStream(str(filename)):
+    print(message.decode())
+
+
+def parse_function(msg: Union[str, bytes], encoding: str = 'utf-8') -> Tuple[bytes, str]:
+    if isinstance(msg, bytes):
+        msg = msg.decode(encoding)
+    nmea_message = re.search(".* (.*)", msg).group(1)  # NMEA
+    metadata = re.search("(.*) .*", msg).group(1)  # Metadata
+
+    return bytes(nmea_message, encoding), metadata
+
+
+filename = pathlib.Path(__file__).parent.joinpath('enhanced_sample.ais')
+
+for message, infos in FileReaderStream(str(filename), parse_function):
+    print(infos, message.decode())

--- a/pyais/stream.py
+++ b/pyais/stream.py
@@ -124,7 +124,7 @@ class AssembleMessages(ABC):
     # this method do unnecessary if else statements: replaced by _yield_field_mapper method
     # @staticmethod
     # def __prepare_yield_value(message: AISSentence, metadata: Any):
-    #     # the worth weakness of this feature is that we break
+    #     # the biggest weakness of this feature is that we break
     #     # the consistency of the output data structure:
     #     # we could imagine for a future version of pyais, with a breaking change (3.y.z),
     #     # to change the global output by (message, metadata) where metadata can be None

--- a/pyais/stream.py
+++ b/pyais/stream.py
@@ -114,6 +114,7 @@ class AssembleMessages(ABC):
                 # Check if all fragments are found
                 not_none_parts = [m for m in msg_parts if m is not None]
                 if len(not_none_parts) == msg.fragment_count:
+                    msg = NMEAMessage.assemble_from_iterable(not_none_parts)
                     msg_with_wrapper = self.__insert_wrapper_msg(msg)
                     yield msg_with_wrapper if metadata is None else (msg_with_wrapper, metadata)
                     del buffer[slot]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ class TestMainApp(unittest.TestCase):
 
     def test_decode_from_file(self):
         class DemoNamespace:
-            in_file = open("ais_test_messages", "rb")
+            in_file = open("tests/ais_test_messages", "rb")
             out_file = None
 
         assert decode_from_file(DemoNamespace()) == 0
@@ -41,7 +41,7 @@ class TestMainApp(unittest.TestCase):
         assert ns.in_file is None
 
         # But this can be overwritten to any file that exists
-        ns = parser.parse_args(["-f", "ais_test_messages"])
+        ns = parser.parse_args(["-f", "tests/ais_test_messages"])
         assert ns.func == decode_from_file
         assert ns.in_file.name == "ais_test_messages"
         ns.in_file.close()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,7 @@ class TestMainApp(unittest.TestCase):
 
     def test_decode_from_file(self):
         class DemoNamespace:
-            in_file = open("tests/ais_test_messages", "rb")
+            in_file = open("ais_test_messages", "rb")
             out_file = None
 
         assert decode_from_file(DemoNamespace()) == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,9 +41,9 @@ class TestMainApp(unittest.TestCase):
         assert ns.in_file is None
 
         # But this can be overwritten to any file that exists
-        ns = parser.parse_args(["-f", "tests/ais_test_messages"])
+        ns = parser.parse_args(["-f", "ais_test_messages"])
         assert ns.func == decode_from_file
-        assert ns.in_file.name == "tests/ais_test_messages"
+        assert ns.in_file.name == "ais_test_messages"
         ns.in_file.close()
 
         # If the file does not exist an error is thrown


### PR DESCRIPTION
It may be useful to read or stream NMEA messages containing any type of metadata
```python
enhanced_fake_stream = [
    b"[2024-07-19 08:45:27.141] !AIVDM,1,1,,A,13HOI:0P0000VOHLCnHQKwvL05Ip,0*23",
    b"[2024-07-19 08:45:30.074] !AIVDM,1,1,,A,133sVfPP00PD>hRMDH@jNOvN20S8,0*7F",
    b"[2024-07-19 08:45:35.007] !AIVDM,1,1,,B,100h00PP0@PHFV`Mg5gTH?vNPUIp,0*3B",
    b"[2024-07-19 08:45:35.301] !AIVDM,1,1,,B,13eaJF0P00Qd388Eew6aagvH85Ip,0*45",
    b"[2024-07-19 08:45:40.021] !AIVDM,1,1,,A,14eGrSPP00ncMJTO5C6aBwvP2D0?,0*7A",
    b"[2024-07-19 08:45:40.074] !AIVDM,1,1,,A,15MrVH0000KH<:V:NtBLoqFP2H9:,0*2F",
]

# Create a custom parsing function:
# - NMEA message must be always in the first position
# - Always consider that the NMEA message are bytes when parsing
# - The metadata field can be also parsed during the process (any types: string, float, datetime, etc.)
def parse_function(line: bytes) -> Tuple[bytes, Any]:
    nmea_message = re.search(b'.* (.*)', line).group(1)  # NMEA
    metadata_bytes = re.search(b'(.*) .*', line).group(1)  # Metadata
    timestamp = datetime.strptime(metadata_bytes.decode("utf-8"), "[%Y-%m-%d %X.%f]").timestamp()
    return nmea_message, timestamp

# Whatever if enhanced_fake_stream datas are bytes or strings:
for message, infos in IterMessages(enhanced_fake_stream, parse_function):
    print(f"Timestamp: {infos} --", message.decode())
```
And the result would be:
```console
Timestamp: 1721371527.141 -- MessageType1(msg_type=1, repeat=0, mmsi=227006760, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=<TurnRate.NO_TI_DEFAULT: -128.0>, speed=0.0, accuracy=False, lon=0.13138, lat=49.475577, course=36.7, heading=511, second=14, maneuver=<ManeuverIndicator.NotAvailable: 0>, spare_1=b'\x00', raim=False, radio=22136)
Timestamp: 1721371530.074 -- MessageType1(msg_type=1, repeat=0, mmsi=205448890, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=<TurnRate.NO_TI_DEFAULT: -128.0>, speed=0.0, accuracy=True, lon=4.419442, lat=51.237658, course=63.3, heading=511, second=15, maneuver=<ManeuverIndicator.NotAvailable: 0>, spare_1=b'\x00', raim=True, radio=2248)
Timestamp: 1721371535.007 -- MessageType1(msg_type=1, repeat=0, mmsi=786434, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=<TurnRate.NO_TI_DEFAULT: -128.0>, speed=1.6, accuracy=True, lon=5.320033, lat=51.967037, course=112.0, heading=511, second=15, maneuver=<ManeuverIndicator.NoSpecialManeuver: 1>, spare_1=b'\x00', raim=False, radio=153208)
Timestamp: 1721371535.301 -- MessageType1(msg_type=1, repeat=0, mmsi=249191000, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=<TurnRate.NO_TI_DEFAULT: -128.0>, speed=0.0, accuracy=True, lon=23.603633, lat=37.955883, course=247.0, heading=511, second=12, maneuver=<ManeuverIndicator.NotAvailable: 0>, spare_1=b'@', raim=False, radio=22136)
Timestamp: 1721371540.021 -- MessageType1(msg_type=1, repeat=0, mmsi=316013198, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=<TurnRate.NO_TI_DEFAULT: -128.0>, speed=0.0, accuracy=True, lon=-130.316237, lat=54.32111, course=237.9, heading=511, second=16, maneuver=<ManeuverIndicator.NotAvailable: 0>, spare_1=b'\x00', raim=True, radio=81935)
Timestamp: 1721371540.074 -- MessageType1(msg_type=1, repeat=0, mmsi=366913120, status=<NavigationStatus.UnderWayUsingEngine: 0>, turn=0.0, speed=0.0, accuracy=False, lon=-64.620662, lat=18.321188, course=329.5, heading=299, second=16, maneuver=<ManeuverIndicator.NotAvailable: 0>, spare_1=b'\x00', raim=True, radio=98890)
```
________________________________________________________________________________
The retro-compatibility is done by a inputs/outputs mapper function:
```python
io_mapper_function = (lambda msg, infos: msg) if parse_function is None else (lambda msg, infos: (msg, infos))
```
It's the biggest weakness of this new feature: we break the consistency of the output data structure.
However, we could imagine for a future version of pyais, with a breaking change (3.y.z), to change the global output to (message, metadata) where metadata can be None.

________________________________________________________________________________
As far as I'm concerned, all the tests passed except:
- test_decode_from_file
- test_parser
- test_invalid_endpoint: because a TCP connection is required?
- test_run_every_file (logic here)

If I change the path ‘tests/ais_test_messages’ to ‘ais_test_messages’ in test_decode_from_file and test_parser then :
- test_decode_from_file is now ok
- test_parser: I get an error ‘[Errno 2] No such file or directory : “/tmp/foo.bar”’ during parsing.

Anyways, when I git checkout on master (without any modifications), the same tests don't pass. Is this normal for these tests? 
