### PR TITLE
Implement Message8 with dac=200 fid=10

### DIFF
--- a/pyais/constants.py
+++ b/pyais/constants.py
@@ -638,3 +638,18 @@ COUNTRY_MAPPING = {
     770: ("UY", "Uruguay"),
     775: ("VE", "Venezuela"),
 }
+
+
+class InlandLoadedType(int, ReprEnum):
+    NotAvailable = 0
+    Loaded = 1
+    Unloaded = 2
+    NotUsed = 3
+
+    @classmethod
+    def _missing_(cls, value: object) -> int:
+        return InlandLoadedType.NotAvailable
+
+    @classmethod
+    def from_value(cls, v: typing.Optional[typing.Any]) -> typing.Optional["InlandLoadedType"]:
+        return cls(v) if v is not None else None

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -856,6 +856,14 @@ def to_10th(v: typing.Union[int, float]) -> float:
     return v / 10.0
 
 
+def from_100th(v: typing.Union[int, float]) -> float:
+    return float(v) * 100.0
+
+
+def to_100th(v: typing.Union[int, float]) -> float:
+    return v / 100.0
+
+
 def from_mmsi(v: typing.Union[str, int]) -> int:
     return int(v)
 

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -10,7 +10,7 @@ import attr
 from bitarray import bitarray
 
 from pyais.constants import TalkerID, NavigationStatus, ManeuverIndicator, EpfdType, ShipType, NavAid, StationType, \
-    TransmitMode, StationIntervals, TurnRate
+    TransmitMode, StationIntervals, TurnRate, InlandLoadedType
 from pyais.exceptions import InvalidNMEAMessageException, TagBlockNotInitializedException, UnknownMessageException, UnknownPartNoException, \
     InvalidDataTypeException, MissingPayloadException
 from pyais.util import checksum, decode_into_bit_array, compute_checksum, get_itdma_comm_state, get_sotdma_comm_state, int_to_bin, str_to_bin, \

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -1082,17 +1082,94 @@ class MessageType7(Payload):
 
 @attr.s(slots=True)
 class MessageType8(Payload):
+    @classmethod
+    def create(cls, **kwargs: typing.Union[str, float, int, bool, bytes]) -> "ANY_MESSAGE":
+        dac: int = int(kwargs.get("dac", 0))
+        fid: int = int(kwargs.get("fid", 0))
+        if dac == 200 and fid == 10:
+            return MessageType8Dac200Fid10.create(**kwargs)
+        else:
+            return MessageType8Default.create(**kwargs)
+
+    @classmethod
+    def from_bitarray(cls, bit_arr: bitarray) -> "ANY_MESSAGE":
+        dac: int = get_int(bit_arr, 40, 50)
+        fid: int = get_int(bit_arr, 50, 56)
+        if dac == 200 and fid == 10:
+            return MessageType8Dac200Fid10.from_bitarray(bit_arr)
+        else:
+            return MessageType8Default.from_bitarray(bit_arr)
+
+
+@attr.s(slots=True)
+class MessageType8Default(Payload):
     """
     Binary Acknowledge
     Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_8_binary_broadcast_message
     """
+
     msg_type = bit_field(6, int, default=8, signed=False)
     repeat = bit_field(2, int, default=0, signed=False)
     mmsi = bit_field(30, int, from_converter=from_mmsi)
-    spare_1 = bit_field(2, bytes, default=b'')
+    spare_1 = bit_field(2, bytes, default=b"")
     dac = bit_field(10, int, default=0, signed=False)
     fid = bit_field(6, int, default=0, signed=False)
-    data = bit_field(952, bytes, default=b'', variable_length=True)
+    data = bit_field(952, bytes, default=b"", variable_length=True)
+
+
+@attr.s(slots=True)
+class MessageType8Dac200Fid10(Payload):
+    """
+    Binary Acknowledge
+    Inland variant with dac=200, fid=10
+
+    Src: https://gpsd.gitlab.io/gpsd/AIVDM.html#_type_8_binary_broadcast_message
+    Msg variant: ECE/TRANS/SC.3/176 page 37
+    https://unece.org/fileadmin/DAM/trans/doc/finaldocs/sc3/ECE-TRANS-SC3-176e.pdf
+    """
+
+    msg_type = bit_field(6, int, default=8, signed=False)
+    repeat = bit_field(2, int, default=0, signed=False)
+    mmsi = bit_field(30, int, from_converter=from_mmsi)
+    spare_1 = bit_field(2, bytes, default=b"")
+    dac = bit_field(10, int, default=0, signed=False)
+    fid = bit_field(6, int, default=0, signed=False)
+    # Unique European Vessel Identification Number / ERI number
+    vin = bit_field(48, str, default="")
+    # 1 - 8000 (rest not to be used) length of ship in 1/10m 0 = default
+    length = bit_field(13, int, from_converter=from_10th, to_converter=to_10th, default=0, signed=False)
+    # 1 - 1000 (rest not to be used) beam of ship in 1/10m; 0 = default
+    beam = bit_field(10, int, from_converter=from_10th, to_converter=to_10th, default=0, signed=False)
+    # Numeric ERI Classification (CODES):
+    # 1 Vessel and Convoy Type as described in ANNEX
+    # E ERI ship types
+    shiptype = bit_field(14, int, default=0, signed=False)
+    # Number of blue cones/lights 0 - 3;
+    # 4 = B-Flag, 5 = default = unknown
+    hazard = bit_field(3, int, default=5, signed=False)
+    # 1 - 2000 (rest not used) draught in 1/100m, 0 = default = unknown
+    draught = bit_field(
+        11,
+        int,
+        from_converter=from_100th,
+        to_converter=to_100th,
+        default=0,
+        signed=False,
+    )
+    # 1 = loaded, 2 = unloaded, 0 = not available/default,, 3 should not be used
+    # InlandLoadedType
+    loaded = bit_field(
+        2,
+        int,
+        default=InlandLoadedType.NotAvailable,
+        from_converter=InlandLoadedType.from_value,
+        to_converter=InlandLoadedType.from_value,
+        signed=False,
+    )
+    speed_q = bit_field(1, bool, default=False)
+    course_q = bit_field(1, bool, default=False)
+    heading_q = bit_field(1, bool, default=False)
+    spare = bit_field(8, bytes)
 
 
 @attr.s(slots=True)

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -33,8 +33,6 @@ from pyais.messages import (
     GatehouseSentence,
     MessageType5,
     MessageType6,
-    MessageType8,
-    MessageType8Default,
     MessageType8Dac200Fid10,
     MessageType18,
     MessageType22Addressed,
@@ -318,10 +316,7 @@ class TestAIS(unittest.TestCase):
         assert msg["mmsi"] == 888888888
         assert msg["dac"] == 0
         assert msg["fid"] == 0
-        assert (
-            msg["data"]
-            == b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM"
-        )
+        assert msg["data"] == b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM"
 
         ensure_type_for_msg_dict(msg)
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -33,6 +33,9 @@ from pyais.messages import (
     GatehouseSentence,
     MessageType5,
     MessageType6,
+    MessageType8,
+    MessageType8Default,
+    MessageType8Dac200Fid10,
     MessageType18,
     MessageType22Addressed,
     MessageType22Broadcast,
@@ -315,9 +318,27 @@ class TestAIS(unittest.TestCase):
         assert msg["mmsi"] == 888888888
         assert msg["dac"] == 0
         assert msg["fid"] == 0
-        assert msg["data"] == b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM"
+        assert (
+            msg["data"]
+            == b"\x02\x934D\x81nI;\xbd\xcd\xe5\xb7E\xed\xf1]\xc0[y\xfa#-\xcd<\x01\x05\x91\xef\x85\x92\xfbF\xed\x19t\x11\xd6\xe7\xdf\xec\x1fp\x97\x99\x83M\x8aK\xb8\x005'\x1f\xc7\x14\xeaTr\xe3o\xb8\xda\xb9\x17-FJxb\xeb5\x1aM"
+        )
 
         ensure_type_for_msg_dict(msg)
+
+    def test_msg_type_8_inland(self):
+        # example from norwegion public AIS feed
+        decoded = decode(b"!BSVDM,1,1,,B,83m;Fa0j2d<<<<<<<0@pUg`50000,0*11")
+        msg = decoded.asdict()
+
+        assert msg["repeat"] == 0
+        assert msg["mmsi"] == 257087140
+        assert msg["dac"] == 200
+        assert msg["fid"] == 10
+        # inland aIS data should be present
+        assert isinstance(decoded, MessageType8Dac200Fid10)
+        assert "beam" in msg
+        # and correct
+        assert msg["beam"] == 7.5
 
     def test_msg_type_9(self):
         msg = decode(b"!AIVDM,1,1,,B,91b55wi;hbOS@OdQAC062Ch2089h,0*30").asdict()

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -12,7 +12,7 @@ from pyais.messages import MessageType1, MessageType26BroadcastUnstructured, Mes
     MessageType25AddressedUnstructured, MessageType25BroadcastStructured, MessageType25AddressedStructured, \
     MessageType24PartB, MessageType24PartA, MessageType22Broadcast, MessageType22Addressed, MessageType27, \
     MessageType23, MessageType21, MessageType20, MessageType19, MessageType18, MessageType17, MessageType16, \
-    MessageType15, MessageType4, MessageType5, MessageType6, MessageType7, MessageType8, MessageType8Default, MessageType2, MessageType3, \
+    MessageType15, MessageType4, MessageType5, MessageType6, MessageType7, MessageType8Default, MessageType2, MessageType3, \
     MSG_CLASS
 from pyais.util import decode_bin_as_ascii6, decode_into_bit_array, str_to_bin, int_to_bin, to_six_bit, encode_ascii_6, \
     int_to_bytes, bits2bytes

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -12,7 +12,7 @@ from pyais.messages import MessageType1, MessageType26BroadcastUnstructured, Mes
     MessageType25AddressedUnstructured, MessageType25BroadcastStructured, MessageType25AddressedStructured, \
     MessageType24PartB, MessageType24PartA, MessageType22Broadcast, MessageType22Addressed, MessageType27, \
     MessageType23, MessageType21, MessageType20, MessageType19, MessageType18, MessageType17, MessageType16, \
-    MessageType15, MessageType4, MessageType5, MessageType6, MessageType7, MessageType8, MessageType2, MessageType3, \
+    MessageType15, MessageType4, MessageType5, MessageType6, MessageType7, MessageType8, MessageType8Default, MessageType2, MessageType3, \
     MSG_CLASS
 from pyais.util import decode_bin_as_ascii6, decode_into_bit_array, str_to_bin, int_to_bin, to_six_bit, encode_ascii_6, \
     int_to_bytes, bits2bytes
@@ -34,7 +34,7 @@ def test_widths():
     tot_width = sum(field.metadata['width'] for field in MessageType7.fields())
     assert tot_width == 168
 
-    tot_width = sum(field.metadata['width'] for field in MessageType8.fields())
+    tot_width = sum(field.metadata['width'] for field in MessageType8Default.fields())
     assert tot_width == 1008
 
     tot_width = sum(field.metadata['width'] for field in MessageType15.fields())
@@ -173,7 +173,7 @@ def test_data_to_payload():
     assert data_to_payload(5, {'mmsi': 123}).__class__ == MessageType5
     assert data_to_payload(6, {'mmsi': 123, 'dest_mmsi': 1234}).__class__ == MessageType6
     assert data_to_payload(7, {'mmsi': 123}).__class__ == MessageType7
-    assert data_to_payload(8, {'mmsi': 123}).__class__ == MessageType8
+    assert data_to_payload(8, {'mmsi': 123}).__class__ == MessageType8Default
 
     with unittest.TestCase().assertRaises(ValueError):
         data_to_payload(28, {'mmsi': 123})


### PR DESCRIPTION
Implements inland Voyage Data (dac=200, fid=10) AIS encoding, as discussed in #174. 
- Add class with inland AIS type (`MessageType8Dac200Fid10`)[Inland ship static and voyage related data (Inland AIS)](https://gpsd.gitlab.io/gpsd/AIVDM.html#_inland_ship_static_and_voyage_related_data_inland_ais)
- Use main class to differentiate between default implementation (binary data kept as is) and MessageType8Dac200Fid10
- Add decoding test based on Norwegian Public AIS 

New PR, I closed the one with the accidental black +onsave turned on. 