### PR TITLE
feat: add json_to_payload() for round-trip decoding/encoding

### DIFF
--- a/pyais/encode.py
+++ b/pyais/encode.py
@@ -1,7 +1,28 @@
+import base64
 import math
 import typing
-
-from pyais.messages import Payload, MSG_CLASS
+from pyais.messages import (
+    ANY_MESSAGE,
+    MSG_CLASS,
+    MessageType8Dac200Fid10,
+    MessageType8Default,
+    MessageType16DestinationA,
+    MessageType16DestinationAB,
+    MessageType22Addressed,
+    MessageType22Broadcast,
+    MessageType24PartA,
+    MessageType24PartB,
+    MessageType24PartBAuxiliaryCraft,
+    MessageType25AddressedStructured,
+    MessageType25AddressedUnstructured,
+    MessageType25BroadcastStructured,
+    MessageType25BroadcastUnstructured,
+    MessageType26AddressedStructured,
+    MessageType26AddressedUnstructured,
+    MessageType26BroadcastStructured,
+    MessageType26BroadcastUnstructured,
+    Payload,
+)
 from pyais.util import chunks, compute_checksum
 
 # Types
@@ -31,6 +52,51 @@ def data_to_payload(ais_type: int, data: DATA_DICT) -> Payload:
         return MSG_CLASS[ais_type].create(**data)
     except KeyError as err:
         raise ValueError(f"AIS message type {ais_type} is not supported") from err
+
+
+_LEAF_MSG_CLS: dict[int, list[type[Payload]]] = {
+    8:  [MessageType8Default, MessageType8Dac200Fid10],
+    16: [MessageType16DestinationA, MessageType16DestinationAB],
+    22: [MessageType22Addressed, MessageType22Broadcast],
+    24: [MessageType24PartA, MessageType24PartB, MessageType24PartBAuxiliaryCraft],
+    25: [MessageType25AddressedStructured, MessageType25AddressedUnstructured,
+         MessageType25BroadcastStructured, MessageType25BroadcastUnstructured],
+    26: [MessageType26AddressedStructured, MessageType26AddressedUnstructured,
+         MessageType26BroadcastStructured, MessageType26BroadcastUnstructured],
+}
+
+_BYTES_FIELDS: dict[int, frozenset[str]] = {
+    msg_type: frozenset(
+        field.name
+        for cls in [typing.cast(type[Payload], interface_cls), *_LEAF_MSG_CLS.get(msg_type, [])]
+        for field in cls.fields()
+        if field.metadata.get('d_type') is bytes
+    )
+    for msg_type, interface_cls in MSG_CLASS.items()
+}
+
+def json_to_payload(data: dict[str, typing.Any]) -> ANY_MESSAGE:
+    """
+    Create a message from the output of Payload().to_json().
+
+    Bytes fields are first base64 decoded.
+    """
+    try:
+        msg_type: int = data['msg_type']
+    except KeyError as err:
+        raise ValueError(f"Missing AIS type field 'msg_type' in '{ data }'") from err
+    
+    try:
+        cls = typing.cast(type[Payload], MSG_CLASS[msg_type])
+    except KeyError as err:
+        raise ValueError(f"AIS message type {msg_type} is not supported") from err
+    
+    for field_name in _BYTES_FIELDS.get(msg_type, frozenset()):
+        value = data.get(field_name)
+        if value is not None:
+            data[field_name] = base64.b64decode(value)
+
+    return cls.create(**data)
 
 
 def ais_to_nmea_0183(

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -1254,7 +1254,7 @@ class MessageType8Dac200Fid10(Payload):
     speed_q = bit_field(1, bool, default=False)
     course_q = bit_field(1, bool, default=False)
     heading_q = bit_field(1, bool, default=False)
-    spare = bit_field(8, bytes, default=0, is_spare=True)
+    spare = bit_field(8, bytes, default=b'', is_spare=True)
 
 
 @attr.s(slots=True)
@@ -1372,7 +1372,7 @@ class MessageType8Dac200Fid40(Payload):
     # The spec encodes nine signal states as decimal digits inside a 30-bit integer field
     status_raw = bit_field(30, int, default=0, signed=False)
 
-    spare_2 = bit_field(11, int, default=0, signed=False)
+    spare_2 = bit_field(11, bytes, default=b'', is_spare=True)
 
     @property
     def status(self) -> list[SignalStatus]:
@@ -2158,7 +2158,7 @@ class MessageType28(Payload):
     charted_status = bit_field(1, int, default=0, signed=False)
     station_status = bit_field(4, int, default=0, signed=False)
     status_bits = bit_field(8, int, default=0, signed=False)
-    spare = bit_field(1, int, default=0, signed=False)
+    spare = bit_field(1, bytes, default=b'', is_spare=True)
     auth = bit_field(1, int, default=0, signed=False)
 
     def parse_dimensions(self) -> ParsedDimensions:

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -763,7 +763,7 @@ class Payload(abc.ABC):
                     bits_in_buffer += width
                 else:
                     required_bits = min(width, len(val) * 8)
-                    int_value = int.from_bytes(val, 'big')
+                    int_value = int.from_bytes(val, 'big') >> (len(val) * 8 - required_bits)  # undo left-alignment from get_bytes()
                     bit_buffer = (bit_buffer << required_bits) | int_value
                     bits_in_buffer += required_bits
             else:
@@ -803,8 +803,11 @@ class Payload(abc.ABC):
 
         # Iterate over each field of the payload class and check for a matching keyword argument.
         # If no matching kwarg was provided use a default value
+        f = cls.fields()
         for field in cls.fields():
             key = field.name
+            if field.name == 'spare_1':
+                a = 1
             try:
                 val = cls.__force_type(field, kwargs[key])
                 args[key] = val

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -2122,7 +2122,7 @@ class MessageType27(Payload):
 
     accuracy = bit_field(1, bool, default=0, signed=False)
     raim = bit_field(1, bool, default=0, signed=False)
-    status = bit_field(4, int, default=NavigationStatus.Undefined, from_converter=NavigationStatus, to_converter=NavigationStatus, signed=False)
+    status = bit_field(4, int, default=NavigationStatus.Undefined, from_converter=NavigationStatus.from_value, signed=False)
     lon = bit_field(18, float, from_converter=from_lat_lon_600, to_converter=to_lat_lon_600, default=0, signed=True)
     lat = bit_field(17, float, from_converter=from_lat_lon_600, to_converter=to_lat_lon_600, default=0, signed=True)
     speed = bit_field(6, float, default=0, signed=False)

--- a/pyais/messages.py
+++ b/pyais/messages.py
@@ -882,7 +882,7 @@ class Payload(abc.ABC):
         return data
 
     def to_json(self, ignore_spare: bool = True) -> str:
-        return AISJSONEncoder(indent=4).encode(self.asdict())
+        return AISJSONEncoder(indent=4).encode(self.asdict(ignore_spare=ignore_spare))
 
 
 #

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -98,7 +98,30 @@ class TestAIS(unittest.TestCase):
 
     maxDiff = None
 
-    def test_to_json(self):
+    def test_to_json_without_spare(self):
+        json_dump = decode(b"!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w428D;,0*24").to_json(ignore_spare=True)
+        text = textwrap.dedent(
+            """{
+    "msg_type": 1,
+    "repeat": 0,
+    "mmsi": 367533950,
+    "status": 0,
+    "turn": -128.0,
+    "speed": 0.0,
+    "accuracy": true,
+    "lon": -122.408232,
+    "lat": 37.808418,
+    "course": 360.0,
+    "heading": 511,
+    "second": 34,
+    "maneuver": 0,
+    "raim": true,
+    "radio": 34059
+}"""
+        )
+        self.assertEqual(json_dump, text)
+
+    def test_to_json_with_spare(self):
         json_dump = decode(b"!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w428D;,0*24").to_json(ignore_spare=False)
         text = textwrap.dedent(
             """{
@@ -115,6 +138,7 @@ class TestAIS(unittest.TestCase):
     "heading": 511,
     "second": 34,
     "maneuver": 0,
+    "spare_1": "AA==",
     "raim": true,
     "radio": 34059
 }"""

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,9 +1,10 @@
+import json
 import unittest
 
 from pyais import encode_dict, encode_msg
 from pyais.constants import InlandLoadedType, NavigationStatus
 from pyais.decode import decode
-from pyais.encode import data_to_payload, get_ais_type
+from pyais.encode import data_to_payload, get_ais_type, json_to_payload
 from pyais.exceptions import UnknownPartNoException
 from pyais.messages import MessageType1, MessageType26BroadcastUnstructured, MessageType26AddressedUnstructured, \
     MessageType26BroadcastStructured, MessageType26AddressedStructured, MessageType25BroadcastUnstructured, \
@@ -178,6 +179,86 @@ def test_data_to_payload():
     with unittest.TestCase().assertRaises(ValueError):
         data_to_payload(29, {'mmsi': 123})
 
+
+def test_json_to_payload():
+    with unittest.TestCase().assertRaises(ValueError) as err:
+        json_to_payload({'mmsi': 123})
+    assert str(err.exception).startswith("Missing AIS type field 'msg_type'")
+
+    assert json_to_payload({'msg_type': 1,'mmsi': 123}).__class__ == MessageType1
+    assert json_to_payload({'msg_type': 2,'mmsi': 123}).__class__ == MessageType2
+    assert json_to_payload({'msg_type': 3,'mmsi': 123}).__class__ == MessageType3
+    assert json_to_payload({'msg_type': 4,'mmsi': 123}).__class__ == MessageType4
+    assert json_to_payload({'msg_type': 5,'mmsi': 123}).__class__ == MessageType5
+    assert json_to_payload({'msg_type': 6,'mmsi': 123, 'dest_mmsi': 1234}).__class__ == MessageType6
+    assert json_to_payload({'msg_type': 7,'mmsi': 123}).__class__ == MessageType7
+    assert json_to_payload({'msg_type': 8,'mmsi': 123}).__class__ == MessageType8Default
+
+    with unittest.TestCase().assertRaises(ValueError):
+        json_to_payload({'msg_type': 29, 'mmsi': 123})
+
+
+def test_json_to_payload_without_spare():
+    result = json_to_payload({
+        'msg_type': 1,
+        "repeat": 0,
+        "mmsi": 367533950,
+        "status": 0,
+        "turn": -128.0,
+        "speed": 0.0,
+        "accuracy": True,
+        "lon": -122.408232,
+        "lat": 37.808418,
+        "course": 360.0,
+        "heading": 511,
+        "second": 34,
+        "maneuver": 0,
+        "raim": True,
+        "radio": 34059
+    })
+    assert isinstance(result, MessageType1)
+    assert result.mmsi == 367533950
+
+    nmea = b"!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w428D;,0*24"
+    json_dump = json.loads(decode(nmea).to_json(ignore_spare=False))
+    encoded = encode_msg(json_to_payload(json_dump), talker_id='AIVDM', radio_channel='A')
+    assert nmea.decode() == encoded[0]
+
+def test_json_to_payload_with_spare():
+    msg = json_to_payload({'msg_type': 1, 'mmsi': 123, 'spare_1': 'oA=='})
+    assert isinstance(msg, MessageType1) and msg.spare_1 == b'\xA0' # = 5
+    msg = json_to_payload({'msg_type': 1, 'mmsi': 123, 'spare_1': 'QA=='})
+    assert isinstance(msg, MessageType1) and msg.spare_1 == b'\x40' # = 1
+    msg = json_to_payload({'msg_type': 1, 'mmsi': 123, 'spare_1': 'gA=='})
+    assert isinstance(msg, MessageType1) and  msg.spare_1 == b'\x80' # = 1
+
+    msg = json_to_payload({
+        'msg_type': 1,
+        "repeat": 0,
+        "mmsi": 367533950,
+        "status": 0,
+        "turn": -128.0,
+        "speed": 0.0,
+        "accuracy": True,
+        "lon": -122.408232,
+        "lat": 37.808418,
+        "course": 360.0,
+        "heading": 511,
+        "second": 34,
+        "maneuver": 0,
+        "spare_1": 'IA==', # b'\x20' 
+        "raim": True,
+        "radio": 34059
+    })
+    assert isinstance(msg, MessageType1) and  msg.spare_1 == b'\x20'
+    assert encode_msg(msg, talker_id='AIVDM', radio_channel='A')[0] == "!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w468D;,0*20"
+
+    # round trip decode / encode
+    nmea = b"!AIVDM,1,1,,A,15NPOOPP00o?b=bE`UNv4?w468D;,0*20"
+    json_dump = json.loads(decode(nmea).to_json(ignore_spare=False))
+    encoded = encode_msg(json_to_payload(json_dump), talker_id='AIVDM', radio_channel='A')
+    assert nmea.decode() == encoded[0]
+    
 
 def test_get_ais_type():
     ais_type = get_ais_type({'type': 1})


### PR DESCRIPTION
 `pyais` can decode AIS messages to JSON (`to_json()`) and encode structured data back to NMEA sentences, but it lacks a direct way to reconstruct a `Payload` object from the JSON output (especially the bytes fields which are base64 encoded). A decode -> JSON -> re-encode round trip was missing.
 
 ## `encode.py`

 * add `json_to_payload(data: dict) -> ANY_MESSAGE` to reconstructed a json produced by `Payload().to_json()`
 * add `_LEAF_MSG_CLS` and `_BYTES_FIELDS` mappings to cover bytes fields automated base64 decoding
 
 ## `messages.py`
 
 * fix bytes left-alignment in `Payload().to_payload()`
 * propagate `ignore_spare` argument through `Paylaod().to_json()`
 * fix spare field types and defaults definition in some MessageTypeX
 * fix `MessageType27.status` converter to use `NavigationStatus.from_value`